### PR TITLE
feat: Enable use of local scorecard CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ pipx install git+https://github.com/oviohub/tap-openssf-scorecard.git@main
 | project_urls        | True     | None    | Project urls (eg. https://github.com/meltano/sdk |
 | start_date          | False    | None    | The earliest record date to sync |
 | api_url             | False    | https://api.mysample.com | The url for the API service |
-| use_local_scorecard_cli| False | False | Use a locally installed version of the scorecard CLI. |
-| local_scorecard_cli_path| False| "./scorecard" | Path to your locally installed version of the scorecard CLI. |
+| local_scorecard_cli_path| False| None    | Path to your locally installed version of the scorecard CLI. The tap uses a docker version by default. |
 | stream_maps         | False    | None    | Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). |
 | stream_map_config   | False    | None    | User-defined config values to be used within map expressions. |
 | flattening_enabled  | False    | None    | 'True' to enable schema flattening and automatically expand nested properties. |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ pipx install git+https://github.com/oviohub/tap-openssf-scorecard.git@main
 | project_urls        | True     | None    | Project urls (eg. https://github.com/meltano/sdk |
 | start_date          | False    | None    | The earliest record date to sync |
 | api_url             | False    | https://api.mysample.com | The url for the API service |
+| use_local_scorecard_cli| False | False | Use a locally installed version of the scorecard CLI. |
+| local_scorecard_cli_path| False| "./scorecard" | Path to your locally installed version of the scorecard CLI. |
 | stream_maps         | False    | None    | Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). |
 | stream_map_config   | False    | None    | User-defined config values to be used within map expressions. |
 | flattening_enabled  | False    | None    | 'True' to enable schema flattening and automatically expand nested properties. |

--- a/tap_openssf_scorecard/client.py
+++ b/tap_openssf_scorecard/client.py
@@ -27,7 +27,8 @@ class openSSFScorecardStream(Stream):
         """
 
         for repo_url in self.config["project_urls"]:
-            if self.config["use_local_scorecard_cli"]:
+            temp_env = {}
+            if self.config["local_scorecard_cli_path"]:
                 cmd = [
                     self.config["local_scorecard_cli_path"],
                     "--show-details",
@@ -46,8 +47,6 @@ class openSSFScorecardStream(Stream):
                     "--format=json",
                     f"--repo={repo_url}",
                 ]
-
-                temp_env = {}
 
             result = subprocess.run(cmd, capture_output=True, env=temp_env)
             if len(result.stdout) == 0:

--- a/tap_openssf_scorecard/client.py
+++ b/tap_openssf_scorecard/client.py
@@ -27,17 +27,30 @@ class openSSFScorecardStream(Stream):
         """
 
         for repo_url in self.config["project_urls"]:
-            cmd = [
-                "docker",
-                "run",
-                "-e",
-                f"GITHUB_AUTH_TOKEN={self.config['auth_token']}",
-                "gcr.io/openssf/scorecard:stable",
-                "--show-details",
-                "--format=json",
-                f"--repo={repo_url}",
-            ]
-            result = subprocess.run(cmd, capture_output=True)
+
+            if self.config["use_local_scorecard_cli"]:
+                cmd = [
+                    "scorecard",
+                    "--show-details",
+                    "--format=json",
+                    f"--repo={repo_url}",
+                ]
+                temp_env = {"GITHUB_AUTH_TOKEN": self.config['auth_token']}
+            else:
+                cmd = [
+                    "docker",
+                    "run",
+                    "-e",
+                    f"GITHUB_AUTH_TOKEN={self.config['auth_token']}",
+                    "gcr.io/openssf/scorecard:stable",
+                    "--show-details",
+                    "--format=json",
+                    f"--repo={repo_url}",
+                ]
+
+                temp_env = {}
+
+            result = subprocess.run(cmd, capture_output=True, env=temp_env)
             if len(result.stdout) == 0:
                 self.logger.error(result.stderr)
                 continue

--- a/tap_openssf_scorecard/client.py
+++ b/tap_openssf_scorecard/client.py
@@ -29,7 +29,7 @@ class openSSFScorecardStream(Stream):
         for repo_url in self.config["project_urls"]:
             if self.config["use_local_scorecard_cli"]:
                 cmd = [
-                    "scorecard",
+                    self.config["local_scorecard_cli_path"],
                     "--show-details",
                     "--format=json",
                     f"--repo={repo_url}",

--- a/tap_openssf_scorecard/client.py
+++ b/tap_openssf_scorecard/client.py
@@ -27,7 +27,6 @@ class openSSFScorecardStream(Stream):
         """
 
         for repo_url in self.config["project_urls"]:
-
             if self.config["use_local_scorecard_cli"]:
                 cmd = [
                     "scorecard",
@@ -35,7 +34,7 @@ class openSSFScorecardStream(Stream):
                     "--format=json",
                     f"--repo={repo_url}",
                 ]
-                temp_env = {"GITHUB_AUTH_TOKEN": self.config['auth_token']}
+                temp_env = {"GITHUB_AUTH_TOKEN": self.config["auth_token"]}
             else:
                 cmd = [
                     "docker",

--- a/tap_openssf_scorecard/tap.py
+++ b/tap_openssf_scorecard/tap.py
@@ -52,7 +52,7 @@ class TapopenSSFScorecard(Tap):
             th.StringType,
             required=False,
             default="./scorecard",
-            description="Change path to your locally installed version of the scorecard CLI.",
+            description="Path to your locally installed version of the scorecard CLI.",
         ),
     ).to_dict()
 

--- a/tap_openssf_scorecard/tap.py
+++ b/tap_openssf_scorecard/tap.py
@@ -40,6 +40,13 @@ class TapopenSSFScorecard(Tap):
             default="https://api.mysample.com",
             description="The url for the API service",
         ),
+        th.Property(
+            "use_local_scorecard_cli",
+            th.BooleanType,
+            required=False,
+            default=False,
+            description="Use a locally installed version of the scorecard cli.",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> list[streams.openSSFScorecardStream]:

--- a/tap_openssf_scorecard/tap.py
+++ b/tap_openssf_scorecard/tap.py
@@ -47,6 +47,13 @@ class TapopenSSFScorecard(Tap):
             default=False,
             description="Use a locally installed version of the scorecard cli.",
         ),
+        th.Property(
+            "local_scorecard_cli_path",
+            th.StringType,
+            required=False,
+            default="./scorecard",
+            description="Change path to your locally installed version of the scorecard CLI.",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> list[streams.openSSFScorecardStream]:

--- a/tap_openssf_scorecard/tap.py
+++ b/tap_openssf_scorecard/tap.py
@@ -41,18 +41,14 @@ class TapopenSSFScorecard(Tap):
             description="The url for the API service",
         ),
         th.Property(
-            "use_local_scorecard_cli",
-            th.BooleanType,
-            required=False,
-            default=False,
-            description="Use a locally installed version of the scorecard CLI.",
-        ),
-        th.Property(
             "local_scorecard_cli_path",
             th.StringType,
             required=False,
-            default="./scorecard",
-            description="Path to your locally installed version of the scorecard CLI.",
+            default="",
+            description=(
+                "Path to your locally installed version of the scorecard CLI. "
+                "The tap uses a docker version by default."
+            ),
         ),
     ).to_dict()
 

--- a/tap_openssf_scorecard/tap.py
+++ b/tap_openssf_scorecard/tap.py
@@ -45,7 +45,7 @@ class TapopenSSFScorecard(Tap):
             th.BooleanType,
             required=False,
             default=False,
-            description="Use a locally installed version of the scorecard cli.",
+            description="Use a locally installed version of the scorecard CLI.",
         ),
         th.Property(
             "local_scorecard_cli_path",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,6 @@ SAMPLE_CONFIG = {
     "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
     "auth_token": os.getenv("TEST_GITHUB_TOKEN"),
     "project_urls": ["https://github.com/meltano/sdk"],
-    "use_local_scorecard_cli": True,
 }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ SAMPLE_CONFIG = {
     "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
     "auth_token": os.getenv("TEST_GITHUB_TOKEN"),
     "project_urls": ["https://github.com/meltano/sdk"],
+    "use_local_scorecard_cli": True,
 }
 
 


### PR DESCRIPTION
Add a config variable letting users decide if they want to use a locally installed version of the scorecard CLI.

The config variable is `use_local_scorecard_cli`
You can also select a specific path using `local_scorecard_cli_path`